### PR TITLE
chore: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ export interface ClassProvider {
 在依赖反转之后，构造函数都依赖抽象而不依赖实例的时候会非常有效。比如下面的例子：
 
 ```ts
-interface Derivable {
+interface Drivable {
   drive(): void;
 }
 
 @Injectable()
 class Student {
-  @Autowired('Derivable')
-  mBike: Derivable;
+  @Autowired('Drivable')
+  mBike: Drivable;
 
   goToSchool() {
     console.log('go to school');
@@ -74,7 +74,7 @@ class Student {
 
 ```ts
 @Injectable()
-class Car implements Derivable {
+class Car implements Drivable {
   drive() {
     console.log('by car')
   }
@@ -82,7 +82,7 @@ class Car implements Derivable {
 
 injector.addProviders(Student)
 injector.addProviders({
-  token: 'Derivable',
+  token: 'Drivable',
   useClass: Car,
 })
 

--- a/test/use-case.test.ts
+++ b/test/use-case.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
+import { Autowired, Inject, Injectable, Injector } from '../src';
 import * as Error from '../src/error';
-import { Autowired, Injectable, Injector, Inject, ClassProvider } from '../src';
 
 describe(__filename, () => {
   it('使用 Autowired 动态注入依赖', () => {
@@ -112,9 +112,10 @@ describe(__filename, () => {
     const c = injector.get(C);
     expect(c).toBeInstanceOf(C);
     expect(c.a).toBeInstanceOf(AImpl);
+    expect(b.a).toBe(c.a);
   });
 
-  it('使用 TypeProvier 创建实例', () => {
+  it('使用 TypeProvider 创建实例', () => {
     @Injectable()
     class A {}
 
@@ -123,7 +124,7 @@ describe(__filename, () => {
     expect(a).toBeInstanceOf(A);
   });
 
-  it('使用 ClassProvier 创建实例', () => {
+  it('使用 ClassProvider 创建实例', () => {
     const token = 'Token';
 
     @Injectable()


### PR DESCRIPTION
Drivable 可用来 drive 的。

Derivable 可派生的。

根据 drive 方法，应当为 Drivable 。

---

Provider typo fix.