### PR TITLE
feat: avoid runtime error `Cannot set property ...`

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -107,6 +107,10 @@ export function Autowired(token?: Token, opts?: InstanceOpts): PropertyDecorator
 
         return this[INSTANCE_KEY];
       },
+      set() {
+        // avoid runtime error: Cannot set property xxx of xxx
+        console.warn(Error.cannotSetPropertyOnAutowired(target, propertyKey));
+      },
     };
 
     // 返回 descriptor，编译工具会自动进行 define

--- a/src/error.ts
+++ b/src/error.ts
@@ -52,3 +52,7 @@ export function noInjectorError(target: object) {
 export function circularError(target: object) {
   return new Error(`在创建 ${stringify(target)} 的时候遇见了循环依赖`);
 }
+
+export function cannotSetPropertyOnAutowired(target: object, key: string | symbol) {
+  return `Cannot set property ${String(key)} of ${stringify(target)} which was decorated by AutoWired.`;
+}

--- a/test/decorator.test.ts
+++ b/test/decorator.test.ts
@@ -222,4 +222,24 @@ describe(__filename, () => {
       }
     }).toThrow(Error.notInjectError(class InjectError {}, 0));
   });
+  it('can avoid runtime error with `Cannot set property on getter`', () => {
+    expect.assertions(1);
+    @Injectable()
+    class A {}
+
+    @Injectable()
+    class B {
+      @Autowired(A)
+      a1!: A | null;
+
+      trySet() {
+        this.a1 = null;
+      }
+    }
+
+    const injector = new Injector();
+    const b = injector.get(B);
+    b.trySet();
+    expect(b.a1).toBeDefined();
+  });
 });


### PR DESCRIPTION
if no `set` function on descriptor, runtime will raise error when we set value to a property which decorated by `AutoWired` func. that's what we donot want to see.

![CleanShot 2022-07-04 at 13 46 18@2x](https://user-images.githubusercontent.com/13938334/177089405-c8a87a55-a75f-4e9f-a945-37fea1170a60.png)
