### PR TITLE
feat: annotate the return type of `getFromDomain`

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -161,7 +161,7 @@ export class Injector {
     return this.createInstance(creator, token, injector, opts, args as ConstructorParameters<K>);
   }
 
-  getFromDomain(...domains: Domain[]) {
+  getFromDomain<T = any>(...domains: Domain[]): Array<T> {
     const tokenSet = new Set<any>();
 
     for (const domain of domains) {


### PR DESCRIPTION
With this change we can use an interface to annotate what is returned from `getFromDomain` so that we can use type hints:

```typescript
@Injectable({ domain: 'A' })
class Car implements Drivable {
  drive() {
    console.log('Driving');
  }
}

const injector = new Injector();
injector.addProviders({ token: 'Drivable', useClass: Car });

const vehicles = injector.getFromDomain<Drivable>('A');
vehicles.forEach(i => i.drive());
```