### PR TITLE
feat: use @abraham/reflection to replace reflect-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release:beta": "npm run release -- --prerelease beta"
   },
   "dependencies": {
-    "reflect-metadata": "^0.1.13"
+    "@abraham/reflection": "^0.12.0"
   },
   "devDependencies": {
     "@commitlint/cli": "17.2.0",

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,4 +1,5 @@
-import 'reflect-metadata';
+import '@abraham/reflection';
+
 import * as Helper from './helper';
 import * as Error from './error';
 import {
@@ -55,7 +56,7 @@ interface InjectOpts {
  * @param token
  */
 export function Inject(token: Token, opts: InjectOpts = {}): ParameterDecorator {
-  return (target, _: Token, index: number) => {
+  return (target, _: string | symbol | undefined, index: number) => {
     Helper.setParameterIn(target, { ...opts, token }, index);
   };
 }
@@ -65,7 +66,7 @@ export function Inject(token: Token, opts: InjectOpts = {}): ParameterDecorator 
  * @param token
  */
 export function Optional(token: Token = Symbol()): ParameterDecorator {
-  return (target, _: Token, index: number) => {
+  return (target, _: string | symbol | undefined, index: number) => {
     Helper.setParameterIn(target, { default: undefined, token }, index);
   };
 }
@@ -78,9 +79,9 @@ export function Autowired(token?: Token, opts?: InstanceOpts): PropertyDecorator
   return (target: object, propertyKey: string | symbol) => {
     const INSTANCE_KEY = Symbol('INSTANCE_KEY');
 
-    let realToken = token as Token;
+    let realToken = token as Token | undefined;
     if (realToken === undefined) {
-      realToken = Reflect.getMetadata('design:type', target, propertyKey);
+      realToken = Reflect.getMetadata<Token>('design:type', target, propertyKey);
     }
 
     if (!Helper.isToken(realToken)) {
@@ -101,7 +102,7 @@ export function Autowired(token?: Token, opts?: InstanceOpts): PropertyDecorator
             throw Error.noInjectorError(this);
           }
 
-          this[INSTANCE_KEY] = injector.get(realToken, opts);
+          this[INSTANCE_KEY] = injector.get(realToken!, opts);
         }
 
         return this[INSTANCE_KEY];

--- a/src/helper/dep-helper.ts
+++ b/src/helper/dep-helper.ts
@@ -4,7 +4,7 @@ import { getParameterDeps } from './parameter-helper';
 import { createConstructorMetadataManager } from './reflect-helper';
 
 const DEP_KEY = Symbol('DEP_KEY');
-const depMeta = createConstructorMetadataManager(DEP_KEY);
+const depMeta = createConstructorMetadataManager<Token[]>(DEP_KEY);
 
 function getDeps(target: object): Token[] {
   return depMeta.get(target) || [];

--- a/src/helper/hook-helper.ts
+++ b/src/helper/hook-helper.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import '@abraham/reflection';
 import {
   IHookStore,
   IDisposable,
@@ -519,7 +519,7 @@ export function markAsHook(
   targetMethod: MethodName,
   options: IHookOptions,
 ) {
-  let hooks = Reflect.getOwnMetadata(HOOK_KEY, target);
+  let hooks = Reflect.getOwnMetadata<IHookMetadata>(HOOK_KEY, target);
   if (!hooks) {
     hooks = [];
     Reflect.defineMetadata(HOOK_KEY, hooks, target);

--- a/src/helper/injector-helper.ts
+++ b/src/helper/injector-helper.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import '@abraham/reflection';
 import { InstanceOpts } from '../declare';
 import type { Injector } from '../injector';
 import { VERSION } from '../constants';
@@ -22,8 +22,8 @@ const defaultInstanceOpts: InstanceOpts = {};
 
 export function markInjectable(target: object, opts: InstanceOpts = defaultInstanceOpts) {
   // 合并的时候只合并当前对象的数据
-  const currentOpts = Reflect.getOwnMetadata(INJECTABLE_KEY, target);
-  Reflect.defineMetadata(INJECTABLE_KEY, { ...opts, ...currentOpts, version: VERSION }, target);
+  const currentOpts = Reflect.getOwnMetadata<InstanceOpts>(INJECTABLE_KEY, target);
+  Reflect.defineMetadata<InstanceOpts>(INJECTABLE_KEY, { ...opts, ...currentOpts, version: VERSION }, target);
 }
 
 export function getInjectableOpts(target: object): InstanceOpts | undefined {

--- a/src/helper/parameter-helper.ts
+++ b/src/helper/parameter-helper.ts
@@ -2,7 +2,7 @@ import { Token, ParameterOpts } from '../declare';
 import { createConstructorMetadataManager } from './reflect-helper';
 
 const PARAMETER_KEY = Symbol('PARAMETER_KEY');
-const parametersMeta = createConstructorMetadataManager(PARAMETER_KEY);
+const parametersMeta = createConstructorMetadataManager<Token[]>(PARAMETER_KEY);
 
 function getParameters(target: object): Token[] {
   return parametersMeta.get(target) || [];
@@ -13,9 +13,9 @@ export function setParameters(target: object, parameters: Token[]) {
 }
 
 const TOKEN_KEY = Symbol('TOKEN_KEY');
-const tokenMeta = createConstructorMetadataManager(TOKEN_KEY);
+const tokenMeta = createConstructorMetadataManager<(ParameterOpts | null)[]>(TOKEN_KEY);
 
-function getParameterTokens(target: object): Array<ParameterOpts | null> {
+function getParameterTokens(target: object): (ParameterOpts | null)[] {
   return tokenMeta.get(target) || [];
 }
 

--- a/src/helper/reflect-helper.ts
+++ b/src/helper/reflect-helper.ts
@@ -1,15 +1,15 @@
-import 'reflect-metadata';
+import '@abraham/reflection';
 
 function findConstructor(target: object) {
   return typeof target === 'object' ? target.constructor : target;
 }
 
-function getConstructorMetadata(metadataKey: any, target: object, propertyKey?: string | symbol) {
+function getConstructorMetadata<MetadataValue>(metadataKey: any, target: object, propertyKey?: string | symbol) {
   const constructor = findConstructor(target);
   if (propertyKey == null) {
-    return Reflect.getMetadata(metadataKey, constructor);
+    return Reflect.getMetadata<MetadataValue>(metadataKey, constructor);
   } else {
-    return Reflect.getMetadata(metadataKey, constructor, propertyKey);
+    return Reflect.getMetadata<MetadataValue>(metadataKey, constructor, propertyKey);
   }
 }
 
@@ -27,10 +27,10 @@ function defineConstructorMetadata(
   }
 }
 
-export function createConstructorMetadataManager(metadataKey: any) {
+export function createConstructorMetadataManager<MetadataValue>(metadataKey: any) {
   return {
-    get(target: object, propertyKey?: string | symbol) {
-      return getConstructorMetadata(metadataKey, target, propertyKey);
+    get(target: object, propertyKey?: string | symbol): MetadataValue | undefined {
+      return getConstructorMetadata<MetadataValue>(metadataKey, target, propertyKey);
     },
     set(metadataValue: any, target: object, propertyKey?: string | symbol) {
       return defineConstructorMetadata(metadataKey, metadataValue, target, propertyKey);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "declaration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "charset": "utf8",
     "pretty": false,
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Currently, this package bundle size is 44KB minified (12KB gzip)
after switch to new reflection library: bundle size is 34KB minified (9KB gzip) 

<img width="1217" alt="image" src="https://github.com/opensumi/di/assets/13938334/51b7b702-86e3-4945-94d5-8a658bffadab">


Size:
- [reflect-metadata](https://github.com/rbuckton/reflect-metadata) is ~50K
- @abraham/reflection is ~3K

