### PR TITLE
feat: make dispose support disposing instance of useFactory

### DIFF
--- a/src/declare.ts
+++ b/src/declare.ts
@@ -75,7 +75,7 @@ interface BasicCreator {
   /**
    * Store the instantiated object.
    */
-  instance?: any;
+  instance?: Set<any>;
   /**
    * Represent this creator is parsed from `Parameter`. and the params of Inject has set `default` attribution.
    */
@@ -83,7 +83,6 @@ interface BasicCreator {
 }
 
 export interface ValueCreator extends BasicCreator {
-  instance: any;
   status: CreatorStatus.done;
 }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -103,7 +103,8 @@ export function Autowired(token?: Token, opts?: InstanceOpts): PropertyDecorator
           }
 
           this[INSTANCE_KEY] = injector.get(realToken, opts);
-          injector.onceInstanceDisposed(this[INSTANCE_KEY], () => {
+          const [creator] = injector.getCreator(realToken);
+          injector.onceInstanceDisposed(creator!, () => {
             this[INSTANCE_KEY] = undefined;
           });
         }

--- a/src/helper/provider-helper.ts
+++ b/src/helper/provider-helper.ts
@@ -45,7 +45,7 @@ export function parseCreatorFromProvider(provider: Provider): InstanceCreator {
 
   if (isValueProvider(provider)) {
     return {
-      instance: provider.useValue,
+      instance: new Set([provider.useValue]),
       isDefault: provider.isDefault,
       status: CreatorStatus.done,
       ...basicObj,

--- a/test/helper/is-function.test.ts
+++ b/test/helper/is-function.test.ts
@@ -76,7 +76,7 @@ describe(__filename, () => {
 
   it('isValueCreator', () => {
     expect(Helper.isValueCreator(factoryProvider)).toBe(false);
-    expect(Helper.isValueCreator({ status: CreatorStatus.done, instance: A })).toBe(true);
+    expect(Helper.isValueCreator({ status: CreatorStatus.done, instance: new Set([A]) })).toBe(true);
   });
 
   it('isFactoryCreator', () => {

--- a/test/helper/provider-helper.test.ts
+++ b/test/helper/provider-helper.test.ts
@@ -47,13 +47,15 @@ describe(__filename, () => {
       parameters: [],
       useClass: A,
     });
-    expect(Helper.parseCreatorFromProvider(valueProvider)).toMatchObject({
-      instance: expect.any(A),
-      status: CreatorStatus.done,
-    });
+
+    const creator = Helper.parseCreatorFromProvider(valueProvider);
+    expect(creator.instance?.has(A)).toBeTruthy;
+    expect(creator.status).toBe(CreatorStatus.done);
+
     expect(Helper.parseCreatorFromProvider(factoryProvider)).toMatchObject({
       useFactory: factoryProvider.useFactory,
     });
+
     expect(Helper.parseCreatorFromProvider(classProvider)).toMatchObject({
       parameters: [],
       useClass: A,

--- a/test/injector.test.ts
+++ b/test/injector.test.ts
@@ -428,13 +428,6 @@ describe('test injector work', () => {
       expect((instance1 as any).__injectorId).toBe(injector.id);
       expect((instance2 as any).__injectorId).toBe(injector.id);
       expect((instance3 as any).__injectorId).toBe(injector.id);
-
-      expect((instance1 as any).__id.startsWith('Instance')).toBeTruthy();
-      console.log(`file: injector.test.ts ~ it ~ (instance1 as any).__id:`, (instance1 as any).__id);
-      expect((instance1 as any).__id).toBe((instance2 as any).__id);
-      expect((instance1 as any).__id).toBe((injector as any).getOrSaveInstanceId(instance1));
-      expect((instance2 as any).__id).toBe((injector as any).getOrSaveInstanceId(instance2));
-      expect((instance1 as any).__id).not.toBe((instance3 as any).__id);
     });
   });
 

--- a/test/injector/hasInstance.test.ts
+++ b/test/injector/hasInstance.test.ts
@@ -25,7 +25,7 @@ describe('hasInstance', () => {
     expect(injector.hasInstance(b)).toBe(true);
 
     const c = injector.get(C);
-    expect(injector.hasInstance(c)).toBe(false);
+    expect(injector.hasInstance(c)).toBe(true);
   });
 
   it('hasInstance 支持 primitive 的判断', () => {
@@ -40,6 +40,6 @@ describe('hasInstance', () => {
     expect(injector.hasInstance(b)).toBe(true);
 
     const c = injector.get(C);
-    expect(injector.hasInstance(c)).toBe(false);
+    expect(injector.hasInstance(c)).toBe(true);
   });
 });


### PR DESCRIPTION
处理 https://github.com/opensumi/di/issues/111

处理方式：把 instance 挂在 creator 上， 形式为一个 `Set` 。原 `instanceDisposedEmitter` 方法，不再以 `instance` 为参数，而是以 `creator` 作为参数。当 creator dispose 时，重置 `creator.instance`。

同时解决以下问题：
- `useFactory` 在 `dispose` 时 instance 无法被删除
- 在之前的情况下 `class provider` 为多例模式时，执行 `dispose` 时，  实例的 `dispose` 方法不会被调用。更新后， 多例的 `class provider` 被 `dispose` 时，其所有实例的 `dispose` 方法都会被调用
- `hasInstance` 无法判别 `useFactory`， 更新后，`useFactory` 的返回值，也可以通过 `hasInstance` 来进行判别。且多例 `class provider` 的 `instance` 同样可以被判别。